### PR TITLE
fixed bug on polygon mask sample

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "react": "^16.4.2",
     "react-dom": "^16.4.2",
-    "react-particles-js": "^3.2.0"
+    "react-particles-js": "^3.3.0"
   },
   "scripts": {
     "start": "parcel public/index.html",

--- a/package.json
+++ b/package.json
@@ -13,12 +13,13 @@
     "parcel": "^1.10.3",
     "react-syntax-highlighter": "^8.0.1",
     "rxjs": "^6.2.2",
+    "sass": "^1.26.5",
     "typescript": "^3.8.3"
   },
   "dependencies": {
     "react": "^16.4.2",
     "react-dom": "^16.4.2",
-    "react-particles-js": "^3.0.3"
+    "react-particles-js": "^3.2.0"
   },
   "scripts": {
     "start": "parcel public/index.html",

--- a/src/components/frame-layout.tsx
+++ b/src/components/frame-layout.tsx
@@ -108,7 +108,7 @@ export class FrameLayout extends React.Component<IProps, IState> {
                         className="github-mark"
                         href="https://github.com/Wufe/react-particles-js"
                         target="_blank"></a>
-                    <span>v3.0.1</span>
+                    <span>v3.2.0</span>
                 </div>
 
             </div>

--- a/src/frames.ts
+++ b/src/frames.ts
@@ -253,7 +253,8 @@ export const frames: TFrame[] = [
                     opacity: .4
                 },
                 move: {
-                    speed: 1
+                    speed: 1,
+                    bounce: false
                 },
                 opacity: {
                     anim: {


### PR DESCRIPTION
The bounce options was "breaking" the polygon mask sample with some points overlapped that was moved away from the polygon